### PR TITLE
Fixed typo in ParseExceptionTests

### DIFF
--- a/ChapterExams/PixelPass.Tests/ParseExceptionTests.cs
+++ b/ChapterExams/PixelPass.Tests/ParseExceptionTests.cs
@@ -13,6 +13,6 @@ public class ParseExceptionTests
     public void _01_Class_ShouldInheritFrom_ParseException()
     {
         Assert.That(ParseExceptionHelper.ClassExistsAndInheritsFromParseException(),
-                    "ParseException should exist and should inherit from ParseException");
+                    "ParseException should exist and should inherit from Exception");
     }
 }


### PR DESCRIPTION
## Description
- Changed `ParseException` to `Exception`. (ChapterExams/PixelPass.Tests/ParseExceptionTests.cs:16)